### PR TITLE
Add device validation after loading layers

### DIFF
--- a/air_llm/airllm/airllm_base.py
+++ b/air_llm/airllm/airllm_base.py
@@ -275,15 +275,65 @@ class AirLLMBaseModel(GenerationMixin):
                         layers.append(layer_name)
 
         for param_name in layers:
-            if (self.hf_quantizer is None or
-                not self.hf_quantizer.check_quantized_param(self.model, param_value=None, param_name=param_name, state_dict={})
-               ):
-                set_module_tensor_to_device(self.model, param_name, self.running_device, value=state_dict[param_name],
-                                            dtype=self.running_dtype,
-                                            )
+            if (
+                self.hf_quantizer is None
+                or not self.hf_quantizer.check_quantized_param(
+                    self.model, param_value=None, param_name=param_name, state_dict={}
+                )
+            ):
+                set_module_tensor_to_device(
+                    self.model,
+                    param_name,
+                    self.running_device,
+                    value=state_dict[param_name],
+                    dtype=self.running_dtype,
+                )
             else:
                 torch_dtype = self.hf_quantizer.update_torch_dtype(None)
-                self.hf_quantizer.create_quantized_param(self.model, state_dict[param_name], param_name, self.running_device, state_dict)
+                self.hf_quantizer.create_quantized_param(
+                    self.model,
+                    state_dict[param_name],
+                    param_name,
+                    self.running_device,
+                    state_dict,
+                )
+
+        # verify that all moved parameters actually reside on the running device
+        def _get_attr(model, name):
+            attrs = name.split(".")
+            mod = model
+            for attr in attrs:
+                if attr.isdigit():
+                    mod = mod[int(attr)]
+                else:
+                    mod = getattr(mod, attr)
+            return mod
+
+        not_loaded = []
+        for param_name in layers:
+            try:
+                param = _get_attr(self.model, param_name)
+                if getattr(param, "device", self.device) == torch.device("meta"):
+                    # attempt one more time in case the first call silently failed
+                    set_module_tensor_to_device(
+                        self.model,
+                        param_name,
+                        self.running_device,
+                        value=state_dict[param_name],
+                        dtype=self.running_dtype,
+                    )
+                    param = _get_attr(self.model, param_name)
+                    if getattr(param, "device", self.device) == torch.device("meta"):
+                        not_loaded.append(param_name)
+            except AttributeError:
+                not_loaded.append(param_name)
+
+        if not_loaded:
+            raise RuntimeError(
+                f"Parameters not properly loaded to device: {not_loaded}. "
+                "Check that the layer files exist and are not corrupted."
+            )
+
         return layers
 
     # make GenerationMixin happy


### PR DESCRIPTION
## Summary
- ensure weights are actually loaded on the running device in `move_layer_to_device`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_684c6b5d94888323874770599ac940cf